### PR TITLE
CommentビヘイビアでBlock.keyを必用としているのにCommentフォームでセットしてなかったのでセットするようにした。

### DIFF
--- a/View/Elements/form.ctp
+++ b/View/Elements/form.ctp
@@ -12,6 +12,7 @@
 
 <div class="row">
 	<div class="col-xs-offset-1 col-xs-11">
+		<?php echo $this->NetCommonsForm->input('Block.key', array('type' => 'hidden', 'value' => Current::read('Block.key'))); ?>
 		<?php echo $this->NetCommonsForm->input('Comment.comment', array(
 				'type' => 'textarea',
 				'class' => 'form-control nc-noresize',


### PR DESCRIPTION
CommentビヘイビアでBlock.keyを必用としているのにCommentフォームでセットしてなかったのでセットするようにしました。